### PR TITLE
Adds config file for DUALSHOCK4

### DIFF
--- a/config/joy_dualshock4.yml
+++ b/config/joy_dualshock4.yml
@@ -1,0 +1,33 @@
+joystick_control:
+  ros__parameters:
+    button_shutdown_1       : 8
+    button_shutdown_2       : 9
+
+    button_motor_off        : 8
+    button_motor_on         : 9
+    
+    button_emd_enable       : 4
+    axis_cmd_linear_x       : 1
+    axis_cmd_angular_z      : 3
+
+    analog_d_pad            : true
+    d_pad_up                : 7
+    d_pad_down              : 7
+    d_pad_left              : 6
+    d_pad_right             : 6
+    # for analog_d_pad
+    d_pad_up_is_positive    : true
+    d_pad_right_is_positive : false
+
+    button_buzzer_enable    : 5
+    dpad_buzzer0            : "up"
+    dpad_buzzer1            : "right"
+    dpad_buzzer2            : "down"
+    dpad_buzzer3            : "left"
+    button_buzzer4          : 2
+    button_buzzer5          : 1
+    button_buzzer6          : 0
+    button_buzzer7          : 3
+    
+    button_sensor_sound_en  : 7
+    button_config_enable    : 6


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
PS4用のゲームパッド、DUALSHOCK4でRaspberry Pi Mouse V3を操作できます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
No

Related PR: https://github.com/rt-net/raspimouse_ros_examples/pull/38

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->  
使用した機材はこちら
 * Raspberry Pi Mouse V3
   * Raspberry Pi 4 Model B
 * PlayStation DUALSHOCK4  
   * 有線接続  

以下のUbuntuマシンで、必要なROS 2ノードを起動し、ゲームパッドで操作できることを確認しました。  
```sh
$ uname -a
Linux ubuntu 5.4.0-1045-raspi #49-Ubuntu SMP PREEMPT Wed Sep 29 17:49:16 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
```

実行したコマンドはこちら。
```sh
$ ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joydev:="/dev/input/js0" joyconfig:=dualshock4 mouse:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->
dmesgのログはこちら。DUALSHOCK4は有線で接続しています。
```sh
[ 2400.171314] input: Sony Interactive Entertainment Wireless Controller Touchpad as /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.1/1-1.1:1.3/0003:054C:09CC.0009/input/input25
[ 2400.171721] input: Sony Interactive Entertainment Wireless Controller Motion Sensors as /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.1/1-1.1:1.3/0003:054C:09CC.0009/input/input26
[ 2400.231306] input: Sony Interactive Entertainment Wireless Controller as /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.1/1-1.1:1.3/0003:054C:09CC.0009/input/input24
[ 2400.231919] sony 0003:054C:09CC.0009: input,hidraw2: USB HID v81.11 Gamepad [Sony Interactive Entertainment Wireless Controller] on usb-0000:01:00.0-1.1/input3
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
