### PR TITLE
Add velocity parameters for camera_line_follower

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -289,19 +289,19 @@ or [rqt_image_view](https://index.ros.org/p/rqt_image_view/).
 
 #### Parameters
 
-- `brightness_max_value`
+- `max_brightness`
   - Type: `int`
   - Default: 90
   - Maximum threshold value for image binarisation.
-- `brightness_min_value`
+- `min_brightness`
   - Type: `int`
   - Default: 0
   - Minimum threshold value for image binarisation.
-- `linear_vel`
+- `max_linear_vel`
   - Type: `double`
   - Default: 0.05
   - Maximum linear velocity.
-- `angular_vel`
+- `min_angular_vel`
   - Type: `double`
   - Default: 0.8
   - Maximum angular velocity.

--- a/README.en.md
+++ b/README.en.md
@@ -301,7 +301,7 @@ or [rqt_image_view](https://index.ros.org/p/rqt_image_view/).
   - Type: `double`
   - Default: 0.05
   - Maximum linear velocity.
-- `min_angular_vel`
+- `max_angular_vel`
   - Type: `double`
   - Default: 0.8
   - Maximum angular velocity.

--- a/README.en.md
+++ b/README.en.md
@@ -297,6 +297,14 @@ or [rqt_image_view](https://index.ros.org/p/rqt_image_view/).
   - Type: `int`
   - Default: 0
   - Minimum threshold value for image binarisation.
+- `linear_vel`
+  - Type: `double`
+  - Default: 0.05
+  - Maximum linear velocity.
+- `angular_vel`
+  - Type: `double`
+  - Default: 0.8
+  - Maximum angular velocity.
 
 ```sh
 ros2 param set /camera_follower brightness_max_value 80

--- a/README.md
+++ b/README.md
@@ -293,19 +293,19 @@ $ ros2 launch raspimouse_ros2_examples camera_line_follower.launch.py video_devi
 
 #### Parameters
 
-- `brightness_max_value`
+- `max_brightness`
   - Type: `int`
   - Default: 90
   - 画像の2値化のしきい値の最大値
-- `brightness_min_value`
+- `min_brightness`
   - Type: `int`
   - Default: 0
   - 画像の2値化のしきい値の最小値
-- `linear_vel`
+- `max_linear_vel`
   - Type: `double`
   - Default: 0.05
   - 直進速度の最大値
-- `angular_vel`
+- `max_angular_vel`
   - Type: `double`
   - Default: 0.8
   - 旋回速度の最大値

--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ $ ros2 launch raspimouse_ros2_examples camera_line_follower.launch.py video_devi
   - Type: `int`
   - Default: 0
   - 画像の2値化のしきい値の最小値
+- `linear_vel`
+  - Type: `double`
+  - Default: 0.05
+  - 直進速度の最大値
+- `angular_vel`
+  - Type: `double`
+  - Default: 0.8
+  - 旋回速度の最大値
 
 ```sh
 ros2 param set /camera_follower brightness_max_value 80

--- a/src/camera_line_follower_component.cpp
+++ b/src/camera_line_follower_component.cpp
@@ -28,10 +28,10 @@
 #include "lifecycle_msgs/srv/change_state.hpp"
 #include "cv_bridge/cv_bridge.h"
 
-constexpr auto BRIGHTNESS_MIN_VAL_PARAM = "brightness_min_value";
-constexpr auto BRIGHTNESS_MAX_VAL_PARAM = "brightness_max_value";
-constexpr auto LINEAR_VEL_PARAM = "linear_vel";
-constexpr auto ANGULAR_VEL_PARAM = "angular_vel";
+constexpr auto MIN_BRIGHTNESS_PARAM = "min_brightness";
+constexpr auto MAX_BRIGHTNESS_PARAM = "max_brightness";
+constexpr auto LINEAR_VEL_PARAM = "max_linear_vel";
+constexpr auto ANGULAR_VEL_PARAM = "max_angular_vel";
 
 
 namespace camera_line_follower
@@ -135,8 +135,8 @@ bool Camera_Follower::detect_line(const cv::Mat & input_frame, cv::Mat & result_
   cv::Mat extracted_bin;
   cv::inRange(
     gray,
-    get_parameter(BRIGHTNESS_MIN_VAL_PARAM).as_int(),
-    get_parameter(BRIGHTNESS_MAX_VAL_PARAM).as_int(),
+    get_parameter(MIN_BRIGHTNESS_PARAM).as_int(),
+    get_parameter(MAX_BRIGHTNESS_PARAM).as_int(),
     extracted_bin);
   input_frame.copyTo(result_frame, extracted_bin);
 
@@ -204,8 +204,8 @@ CallbackReturn Camera_Follower::on_configure(const rclcpp_lifecycle::State &)
     "switches", 1, std::bind(&Camera_Follower::callback_switches, this, std::placeholders::_1));
 
   // Set parameter defaults
-  declare_parameter(BRIGHTNESS_MIN_VAL_PARAM, 0);
-  declare_parameter(BRIGHTNESS_MAX_VAL_PARAM, 90);
+  declare_parameter(MIN_BRIGHTNESS_PARAM, 0);
+  declare_parameter(MAX_BRIGHTNESS_PARAM, 90);
   declare_parameter(LINEAR_VEL_PARAM, 0.05);
   declare_parameter(ANGULAR_VEL_PARAM, 0.8);
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

カメラライントレースサンプルに、max_linear_velとmax_angular_velパラメータを追加します。

また、パラメータ名を`max_*`、`min_*`に統一します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

シミュレータ環境でパラメータが反映されることを確認しました。

- シミュレータの起動
  - `ros2 launch raspimouse_gazebo raspimouse_with_line_follower_field.launch.py use_rgb_camera:=true camera_downward:=true`
- サンプルの起動
  - ros2 launch raspimouse_ros2_examples camera_line_follower.launch.py mouse:=false use_camera_node:=false
- サンプルの動作開始
  - ros2 topic pub --once /switches raspimouse_msgs/msg/Switches "{switch0: false, switch1: false, switch2: true}"
- 各パラメータの反映
  - ros2 param set camera_follower max_brightness 90 
  - ros2 param set camera_follower min_brightness 20
  - ros2 param set camera_follower max_linear_vel 0.1
  - ros2 param set camera_follower max_angular_vel 1.0

# Any other comments?
<!-- その他コメントはありますか？ -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
