### PR TITLE
SubscriberとService Clientに別々のcallback_groupを設定

### DIFF
--- a/launch/teleop_joy.launch.py
+++ b/launch/teleop_joy.launch.py
@@ -24,6 +24,7 @@ from launch.actions import SetLaunchConfiguration
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.actions import LifecycleNode
+from launch.events import Shutdown
 
 
 def generate_launch_description():
@@ -65,7 +66,8 @@ def generate_launch_description():
     joystick_control_node = Node(
         package='raspimouse_ros2_examples',
         executable='joystick_control.py',
-        parameters=[LaunchConfiguration('joyconfig_filename')]
+        parameters=[LaunchConfiguration('joyconfig_filename')],
+        on_exit=Shutdown(),
     )
 
     def func_launch_mouse_node(context):

--- a/raspimouse_ros2_examples/joystick_control.py
+++ b/raspimouse_ros2_examples/joystick_control.py
@@ -124,16 +124,6 @@ class JoyWrapper(Node):
         self._sub_cb_group = MutuallyExclusiveCallbackGroup()
         self._client_cb_group = MutuallyExclusiveCallbackGroup()
 
-        self._sub_joy = self.create_subscription(
-            Joy, 'joy', self._callback_joy, 1,
-            callback_group=self._sub_cb_group)
-        self._sub_lightsensor = self.create_subscription(
-            LightSensors, 'light_sensors', self._callback_lightsensors, 1,
-            callback_group=self._sub_cb_group)
-        self._sub_switches = self.create_subscription(
-            Switches, 'switches', self._callback_switches, 1,
-            callback_group=self._sub_cb_group)
-
         self._client_get_state = self.create_client(
             GetState, 'raspimouse/get_state', callback_group=self._client_cb_group)
         while not self._client_get_state.wait_for_service(timeout_sec=1.0):
@@ -150,6 +140,16 @@ class JoyWrapper(Node):
         while not self._client_motor_power.wait_for_service(timeout_sec=1.0):
             self._node_logger.warn(self._client_motor_power.srv_name + ' service not available')
         self._motor_on()
+
+        self._sub_joy = self.create_subscription(
+            Joy, 'joy', self._callback_joy, 1,
+            callback_group=self._sub_cb_group)
+        self._sub_lightsensor = self.create_subscription(
+            LightSensors, 'light_sensors', self._callback_lightsensors, 1,
+            callback_group=self._sub_cb_group)
+        self._sub_switches = self.create_subscription(
+            Switches, 'switches', self._callback_switches, 1,
+            callback_group=self._sub_cb_group)
 
     def _activate_raspimouse(self):
         self._set_mouse_lifecycle_state(Transition.TRANSITION_CONFIGURE)

--- a/raspimouse_ros2_examples/joystick_control.py
+++ b/raspimouse_ros2_examples/joystick_control.py
@@ -29,6 +29,7 @@ from raspimouse_msgs.msg import Switches
 
 import rclpy
 from rclpy.node import Node
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from sensor_msgs.msg import Joy
 from std_msgs.msg import Int16
 from std_srvs.srv import SetBool
@@ -120,23 +121,32 @@ class JoyWrapper(Node):
         self._pub_buzzer = self.create_publisher(Int16, 'buzzer', 1)
         self._pub_leds = self.create_publisher(Leds, 'leds', 1)
 
-        self._sub_joy = self.create_subscription(
-            Joy, 'joy', self._callback_joy, 1)
-        self._sub_lightsensor = self.create_subscription(
-            LightSensors, 'light_sensors', self._callback_lightsensors, 1)
-        self._sub_switches = self.create_subscription(
-            Switches, 'switches', self._callback_switches, 1)
+        self._sub_cb_group = MutuallyExclusiveCallbackGroup()
+        self._client_cb_group = MutuallyExclusiveCallbackGroup()
 
-        self._client_get_state = self.create_client(GetState, 'raspimouse/get_state')
+        self._sub_joy = self.create_subscription(
+            Joy, 'joy', self._callback_joy, 1,
+            callback_group=self._sub_cb_group)
+        self._sub_lightsensor = self.create_subscription(
+            LightSensors, 'light_sensors', self._callback_lightsensors, 1,
+            callback_group=self._sub_cb_group)
+        self._sub_switches = self.create_subscription(
+            Switches, 'switches', self._callback_switches, 1,
+            callback_group=self._sub_cb_group)
+
+        self._client_get_state = self.create_client(
+            GetState, 'raspimouse/get_state', callback_group=self._client_cb_group)
         while not self._client_get_state.wait_for_service(timeout_sec=1.0):
             self._node_logger.warn(self._client_get_state.srv_name + ' service not available')
 
-        self._client_change_state = self.create_client(ChangeState, 'raspimouse/change_state')
+        self._client_change_state = self.create_client(
+            ChangeState, 'raspimouse/change_state', callback_group=self._client_cb_group)
         while not self._client_change_state.wait_for_service(timeout_sec=1.0):
             self._node_logger.warn(self._client_change_state.srv_name + ' service not available')
         self._activate_raspimouse()
 
-        self._client_motor_power = self.create_client(SetBool, 'motor_power')
+        self._client_motor_power = self.create_client(
+            SetBool, 'motor_power', callback_group=self._client_cb_group)
         while not self._client_motor_power.wait_for_service(timeout_sec=1.0):
             self._node_logger.warn(self._client_motor_power.srv_name + ' service not available')
         self._motor_on()
@@ -194,6 +204,7 @@ class JoyWrapper(Node):
             self._motor_off()
             self._set_mouse_lifecycle_state(Transition.TRANSITION_DEACTIVATE)
             self.destroy_node()
+            raise SystemExit
 
     def _joy_motor_onoff(self, joy_msg):
         if joy_msg.buttons[self._BUTTON_MOTOR_ON]:
@@ -397,7 +408,10 @@ def main(args=None):
 
     joy_wrapper = JoyWrapper()
 
-    rclpy.spin(joy_wrapper)
+    try:
+        rclpy.spin(joy_wrapper)
+    except SystemExit:
+        rclpy.logging.get_logger("joystick_control").info('_joy_shutdown() has been executed')
 
     joy_wrapper.destroy_node()
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
#56 で指摘されている問題を解決するためにSubscriberとService Clientに別々のcallback_groupを設定します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
#56 に対応します。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機のRaspberry Pi Mouseでジョイスティックコントローラから全てのノードを停止できることを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->

## ノードの終了方法
joystick_controlノードの中でjoystick_controlノードの削除を行った後はターミナルがそのまま停止してしまうので、下記の行にて手動で例外を発生させて終了させています。この方法で問題ないか確認いただきたいです。
https://github.com/rt-net/raspimouse_ros2_examples/blob/set_callback_group/raspimouse_ros2_examples/joystick_control.py#L207

参考：https://answers.ros.org/question/406469/ros-2-how-to-quit-a-node-from-within-a-callback/

## callback_groupの種類
下記のどちらのcallback_groupでも正常に動きますが、どちらがよいかなど確認していただきたいです。

- MutuallyExclusiveCallbackGroup() → グループ内で並列処理できない
- ReentrantCallbackGroup() → グループ内で並列処理できる

参考：https://docs.ros.org/en/humble/How-To-Guides/Using-callback-groups.html

## 終了時の処理のログ
ジョイスティックコントローラからシャットダウン処理を行った際、すべてのノードが終了することは確認できましたが、下記のようにエラーのログが出ています。これで問題ないか確認していただきたいです。

```
[raspimouse-3] [INFO] [1723095315.346715360] [raspimouse]: Deactivating node
[raspimouse-3] [INFO] [1723095315.346896007] [raspimouse]: Turned motors off
[raspimouse-3] [INFO] [1723095315.347719091] [raspimouse]: Turned motors off
[joystick_control.py-2] [INFO] [1723095315.768695813] [joystick_control]: _joy_shutdown() has been executed
[INFO] [joystick_control.py-2]: process has finished cleanly [pid 7848]
[ERROR] [launch]: Caught exception in launch (see debug for traceback): expected a LaunchDescriptionEntity from event_handler, got '<launch.events.shutdown.Shutdown object at 0xffff8a1d4e20>'
[INFO] [raspimouse-3]: sending signal 'SIGINT' to process[raspimouse-3]
[INFO] [joy_linux_node-1]: sending signal 'SIGINT' to process[joy_linux_node-1]
[raspimouse-3] [INFO] [1723095316.570058723] [rclcpp]: signal_handler(signum=2)
[raspimouse-3] [INFO] [1723095316.571776336] [raspimouse]: Turned motors off
[joy_linux_node-1] [INFO] [1723095316.574347293] [rclcpp]: signal_handler(signum=2)
[raspimouse-3] [ERROR] [1723095316.581752111] [raspimouse]: Unable to start transition 6 from current state shuttingdown: Could not publish transition: publisher's context is invalid, at ./src/rcl/publisher.c:389, at ./src/rcl_lifecycle.c:368
[raspimouse-3] [WARN] [1723095316.581824166] [rclcpp_lifecycle]: Shutdown error in destruction of LifecycleNode: final state(shuttingdown)
[joy_linux_node-1] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[joy_linux_node-1]   what():  failed to create guard condition: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at ./src/rcl/guard_condition.c:67
[INFO] [raspimouse-3]: process has finished cleanly [pid 7850]
[ERROR] [joy_linux_node-1]: process has died [pid 7846, exit code -6, cmd '/opt/ros/humble/lib/joy_linux/joy_linux_node --ros-args --params-file /tmp/launch_params_972nvo76'].
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
