### PR TITLE
Service Clientでexecutorを使用しないように変更

### DIFF
--- a/raspimouse_ros2_examples/joystick_control.py
+++ b/raspimouse_ros2_examples/joystick_control.py
@@ -161,14 +161,12 @@ class JoyWrapper(Node):
         request = ChangeState.Request()
         request.transition.id = transition_id
         future = self._client_change_state.call_async(request)
-        executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
-        rclpy.spin_until_future_complete(self, future, executor=executor)
+        rclpy.spin_until_future_complete(self, future)
         return future.result().success
 
     def _get_mouse_lifecycle_state(self):
         future = self._client_get_state.call_async(GetState.Request())
-        executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
-        rclpy.spin_until_future_complete(self, future, executor=executor)
+        rclpy.spin_until_future_complete(self, future)
         return future.result().current_state.label
 
     def _motor_request(self, request_data=False):


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
joystick_control.pyにおいて使用していたexecutorの記述を削除します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
https://github.com/rt-net/raspimouse_ros2_examples/issues/57 に対応します。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機とシミュレータ環境でジョイスティックコントローラのサンプルが動くことを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->
参考: https://docs.ros.org/en/foxy/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.html

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
